### PR TITLE
BUG: Removed open() as it was reading in utf-8 and isn't necessary.

### DIFF
--- a/needle/engines/perceptualdiff_engine.py
+++ b/needle/engines/perceptualdiff_engine.py
@@ -13,7 +13,7 @@ class Engine(EngineBase):
 
     def assertSameFiles(self, output_file, baseline_file, threshold):
         # Calculate threshold value as a pixel number instead of percentage.
-        width, height = Image.open(open(output_file)).size
+        width, height = Image.open(output_file).size
         threshold = int(width * height * threshold)
 
         diff_ppm = output_file.replace(".png", ".diff.ppm")


### PR DESCRIPTION
Small little change. The `open` was breaking py3. I could've added a `rb` to fix the problem but figured why not let `Pillow` handle it.
