### PR TITLE
Make viewport resize optional

### DIFF
--- a/needle/cases.py
+++ b/needle/cases.py
@@ -50,6 +50,8 @@ class NeedleTestCase(TestCase):
 
     viewport_width = 1024
     viewport_height = 768
+    
+    resize_viewport = True
 
     engine_class = 'needle.engines.pil_engine.Engine'
 
@@ -65,8 +67,10 @@ class NeedleTestCase(TestCase):
         cls.engine = klass()
 
         cls.driver = cls.get_web_driver()
-        cls.driver.set_window_position(0, 0)
-        cls.set_viewport_size(cls.viewport_width, cls.viewport_height)
+        if cls.resize_viewport:
+            cls.driver.set_window_position(0, 0)
+            cls.set_viewport_size(cls.viewport_width, cls.viewport_height)
+            
         super(NeedleTestCase, cls).setUpClass()
 
     @classmethod


### PR DESCRIPTION
Due to some Webdrivers not supporting window handling, a flag to do the window resize and positioning should be implemented.
I ran into problems using Opera and Android
