### PR TITLE
Method to compare two screenshots. This is useful if you want to compare...

### DIFF
--- a/needle/cases.py
+++ b/needle/cases.py
@@ -200,6 +200,6 @@ class NeedleTestCase(TestCase):
     def assertCompareScreenshot(self, file1, file2, threshold=0):
         baseline_file = os.path.join(self.output_directory, '%s.png' % file1)
         output_file = os.path.join(self.output_directory, '%s.png' % file2)
-	if not os.path.exists(baseline_file):
+        if not os.path.exists(baseline_file):
                     raise IOError('File 1 does not exist')
-	self.engine.assertSameFiles(output_file, baseline_file, threshold)
+        self.engine.assertSameFiles(output_file, baseline_file, threshold)

--- a/needle/cases.py
+++ b/needle/cases.py
@@ -196,3 +196,10 @@ class NeedleTestCase(TestCase):
                 element.get_screenshot().save(output_file)
 
                 self.engine.assertSameFiles(output_file, baseline_file, threshold)
+    
+    def assertCompareScreenshot(self, file1, file2, threshold=0):
+        baseline_file = os.path.join(self.output_directory, '%s.png' % file1)
+        output_file = os.path.join(self.output_directory, '%s.png' % file2)
+	if not os.path.exists(baseline_file):
+                    raise IOError('File 1 does not exist')
+	self.engine.assertSameFiles(output_file, baseline_file, threshold)


### PR DESCRIPTION
... two screenshots rather than baseline <-> screenshot comparision.

For example to compare an element that is present in more than one page.

```
def test_element_all(self):
    if not self.save_baseline:
        self.assertCompareScreenshot('global.home', 'global.otherpage')
        self.assertCompareScreenshot('global.home', 'global.innerpage')
        self.assertCompareScreenshot('global.otherpage', 'global.innerpage')

    def test_element_home(self):
        self.driver.get(self.base_url + 'home.htm')
        # hier machen wir den screenshot mit dem CSS Selektor im 1. Parametern und den Screenshot namen als 2. Parametern
        self.assertScreenshot("#header", "global.home")

    def test_element_otherpage(self):
        self.driver.get(self.base_url + 'looks.detail_L040.htm')
        # hier machen wir den screenshot mit dem CSS Selektor im 1. Parametern und den Screenshot namen als 2. Parametern
        self.assertScreenshot("#header", "global.otherpage")

    def test_element_innerpage(self):
        self.driver.get(self.base_url + 'shoppingbag.full_G010.htm')
        # hier machen wir den screenshot mit dem CSS Selektor im 1. Parametern und den Screenshot namen als 2. Parametern
        self.assertScreenshot("#header", "global.innerpage")
```