### PR TITLE
Add cleanup_on_success option

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -130,6 +130,28 @@ image and the new screenshot. Note that you will need to
 place it in your ``PATH`` for this to work.
 
 
+File cleanup
+------------
+
+Each time you run tests, Needle will create new screenshot images on disk, for
+comparison with the baseline screenshots. It's then up to you whether you want
+to delete them or archive them.
+
+Set the ``cleanup_on_success`` class attribute to ``True`` to delete these
+files for all successful tests. Any screenshots that differ from the baseline
+will remain on disk for your inspection. Example::
+
+    from needle.cases import NeedleTestCase
+
+    class MyTests(NeedleTestCase):
+        cleanup_on_success = True
+
+        def test_something(self):
+            ...
+
+By default, ``cleanup_on_success`` is ``False``.
+
+
 Indices and tables
 ------------------
 

--- a/needle/cases.py
+++ b/needle/cases.py
@@ -47,6 +47,7 @@ class NeedleTestCase(TestCase):
 
     capture = False  # Deprecated
     save_baseline = False
+    cleanup_on_success = False
 
     viewport_width = 1024
     viewport_height = 768
@@ -59,6 +60,8 @@ class NeedleTestCase(TestCase):
             cls.capture = True
         if os.environ.get('NEEDLE_SAVE_BASELINE'):
             cls.save_baseline = True
+        if os.environ.get('NEEDLE_CLEANUP_ON_SUCCESS'):
+            cls.cleanup_on_success = True
 
         # Instantiate the diff engine
         klass = import_from_string(cls.engine_class)
@@ -195,4 +198,10 @@ class NeedleTestCase(TestCase):
                 # Save the new screenshot
                 element.get_screenshot().save(output_file)
 
-                self.engine.assertSameFiles(output_file, baseline_file, threshold)
+                try:
+                    self.engine.assertSameFiles(output_file, baseline_file, threshold)
+                except:
+                    raise
+                else:
+                    if self.cleanup_on_success:
+                        os.remove(output_file)

--- a/needle/plugin.py
+++ b/needle/plugin.py
@@ -41,3 +41,26 @@ class SaveBaselinePlugin(Plugin):
     def beforeTest(self, test):
         if hasattr(test, 'test'):
             test.test.save_baseline = True
+
+
+
+class CleanUpOnSuccessPlugin(Plugin):
+    """
+    A nose plugin that causes all successful ``NeedleTestCase.assertScreenshot``
+    calls to delete the non-baseline file from disk.
+    """
+    name = 'needle-cleanup-on-success'
+
+    def add_options(self, parser, env=None):
+        super(CleanUpOnSuccessPlugin, self).add_options(parser, env)
+
+    def wantClass(self, cls):
+        # Only gather classes which are a needle test case
+        return hasattr(cls, 'assertScreenshot')
+
+    def wantFunction(self, f):
+        return False
+
+    def beforeTest(self, test):
+        if hasattr(test, 'test'):
+            test.test.cleanup_on_success = True

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
     entry_points = {
         'nose.plugins.0.10': [
             'needle-capture = needle.plugin:NeedleCapturePlugin',
-            'save-baseline = needle.plugin:SaveBaselinePlugin'
+            'save-baseline = needle.plugin:SaveBaselinePlugin',
+            'needle-cleanup-on-success = needle.plugin:CleanUpOnSuccessPlugin',
         ]
     },
     install_requires=install_requires,


### PR DESCRIPTION
Whenever I run my needle-powered tests, needle creates a screenshot image for each test so that it can compare with the baseline screenshots. But after the tests finish, the new screenshot files remain, and I need to delete them manually. Sometimes I inadvertently check them in to revision control, and it's a bit of an annoyance to deal with.

To avoid having to delete them each time I run tests, I've added an option to needle to specify that the screenshot files should be deleted after the tests run, except for screenshots that differ from the baseline.

This pull request adds support for a cleanup_on_success class attribute. If you set it to True, then needle will delete the screenshots after each test run (except for those that differ from the baseline, so you can inspect them). It's set to False by default, for backwards compatibility.

One problem: I tried adding a CleanUpOnSuccessPlugin in order to support "--needle-cleanup-on-success" from the command line, but I couldn't get it to work. Seems like I'm not hooking into the nose plugin API correctly? Also, there are no unit tests for this feature, as I wasn't sure how to write them in test_plugin.py without the plugin working.