### PR TITLE
added whitelist

### DIFF
--- a/needle/cases.py
+++ b/needle/cases.py
@@ -124,7 +124,7 @@ class NeedleTestCase(TestCase):
 
         cls.driver.set_window_size(width + delta, height)
 
-    def assertScreenshot(self, element_or_selector, file, threshold=0):
+    def assertScreenshot(self, element_or_selector, file, whitelist=[], threshold=0):
         """assert-style variant of compareScreenshot context manager
 
         compareScreenshot() can be considerably more efficient for recording baselines by avoiding the need
@@ -132,11 +132,11 @@ class NeedleTestCase(TestCase):
         to continue using normal unittest-style assertions if you don't need the efficiency benefits
         """
 
-        with self.compareScreenshot(element_or_selector, file, threshold=threshold):
+        with self.compareScreenshot(element_or_selector, file, whitelist=whitelist, threshold=threshold):
             pass
 
     @contextmanager
-    def compareScreenshot(self, element_or_selector, file, threshold=0):
+    def compareScreenshot(self, element_or_selector, file, whitelist = [], threshold=0):
         """
         Assert that a screenshot of an element is the same as a screenshot on disk,
         within a given threshold.
@@ -149,11 +149,18 @@ class NeedleTestCase(TestCase):
             If a string, then assumed to be the filename for the screenshot,
             which will be appended with ``.png``. Otherwise assumed to be
             a file object for the baseline image.
+        :param whitelist:
+            element found by this array of css selector will be set to visibility hidden in order avoid making test fails
         :param threshold:
             The threshold for triggering a test failure.
         """
 
         yield  # To allow using this method as a context manager
+
+        if len(whitelist) > 0:
+            for whiteListThis in whitelist:
+                script = "document.querySelector('"+whiteListThis+"').style.visibility = 'hidden'"
+                self.driver.execute_script(script)
 
         if not isinstance(element_or_selector, NeedleWebElement):
             element = self.driver.find_element_by_css_selector(element_or_selector)


### PR DESCRIPTION
Now you can pass a whitelist of css selector.
If css selectors matches somethings, those elements visibility will be set to "hidden" in order to avoid screenshot comparison failures on elements that can, by nature, change.