### PR TITLE
added devicePixelRatio support

### DIFF
--- a/needle/driver.py
+++ b/needle/driver.py
@@ -41,13 +41,16 @@ class NeedleWebElement(WebElement):
         Returns a dictionary containing, in pixels, the element's ``width`` and
         ``height``, and it's ``left`` and ``top`` position relative to the document.
         """
+
+        # Support for retina displays
+        dpr = self._parent.execute_script('return window.devicePixelRatio')
         location = self.location
         size = self.size
         return {
-            "top": location['y'],
-            "left": location['x'],
-            "width": size['width'],
-            "height": size['height']
+            "top": location['y'] * dpr,
+            "left": location['x'] * dpr,
+            "width": size['width'] * dpr,
+            "height": size['height'] * dpr
         }
 
     def get_screenshot(self):


### PR DESCRIPTION
Support for screens that have a greater devicePixelRatio than 1. 

There may be another way to do this, because baselines created on a retina display will fail when run on a regular display and vice versa. 

I'm not very familiar with this module, but I'd imagine exposing the ability to set this implicitly to a developer, rather than calculating it automatically might be a better option. 

Currently in my project I am doing this: 

```python
def get_dimensions(cls):
    # Support for retina displays
    dpr = cls._parent.execute_script('return window.devicePixelRatio')
    location = cls.location
    size = cls.size
    return {
        "top": location['y'] * dpr,
        "left": location['x'] * dpr,
        "width": size['width'] * dpr,
        "height": size['height'] * dpr
    }
    
NeedleWebElement.get_dimensions = get_dimensions
```

Browser support for devicePixelRatio: http://caniuse.com/#search=devicePixelRatio