### PR TITLE
Updates and testing for Chrome and Firefox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
 *.egg-info
 .DS_Store
+.idea/
+.tox/
 *~
 .*.swo
 .*.swp
@@ -10,6 +12,8 @@
 /dist/
 selenium-server-standalone-*.jar
 /docs/_build
+/screenshots/
 tests/screenshots/*.png
+geckodriver.log
 ghostdriver.log
 __pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ before_install:
   - sleep 3 # give xvfb some time to start
   - sudo apt-get update -qq
   - sudo apt-get install -y perceptualdiff imagemagick
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.15.0/geckodriver-v0.15.0-linux64.tar.gz
+  - mkdir geckodriver
+  - tar -xzf geckodriver-v0.15.0-linux64.tar.gz -C geckodriver
+  - export PATH=$PATH:$PWD/geckodriver
 addons:
   firefox: '52.0'
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,20 @@ python:
   - "3.5"
   - "3.6"
 env:
-  - SELENIUM_VERSION='<3'
-  - SELENIUM_VERSION='<4'
+  - SELENIUM_VERSION='<3' NEEDLE_BROWSER=phantomjs
+  - SELENIUM_VERSION='<4' NEEDLE_BROWSER=phantomjs
+  - SELENIUM_VERSION='<3' NEEDLE_BROWSER=firefox
+  - SELENIUM_VERSION='<4' NEEDLE_BROWSER=firefox
 before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
   - sudo apt-get update -qq
   - sudo apt-get install -y perceptualdiff imagemagick
+addons:
+  firefox: '52.0'
 install:
   - pip install "selenium ${SELENIUM_VERSION}"
   - pip install -e .
 script:
-  - NEEDLE_BROWSER=phantomjs nosetests -v
+  - nosetests -v

--- a/needle/cases.py
+++ b/needle/cases.py
@@ -6,6 +6,7 @@ from warnings import warn
 from contextlib import contextmanager
 from errno import EEXIST
 import os
+import signal
 import sys
 
 if sys.version_info > (2, 7):
@@ -78,6 +79,9 @@ class NeedleTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        if isinstance(cls.driver, NeedlePhantomJS):
+            # Workaround for https://github.com/SeleniumHQ/selenium/issues/767
+            cls.driver.service.process.send_signal(signal.SIGTERM)
         cls.driver.quit()
         super(NeedleTestCase, cls).tearDownClass()
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,6 @@
 import sys
 import os
+from errno import EEXIST
 
 from needle.plugin import NeedleCapturePlugin, SaveBaselinePlugin, CleanUpOnSuccessPlugin
 from nose.plugins import PluginTester
@@ -13,6 +14,20 @@ else:
 baseline_filename = 'screenshots/baseline/red_box.png'
 screenshot_filename = 'screenshots/red_box.png'
 dummy_baseline_content = b'abcd'
+
+
+def create_baseline_dir():
+    """
+    Create the baseline images directory if it doesn't already exist.
+    """
+    dir_path = 'screenshots/baseline'
+    try:
+        os.makedirs(dir_path)
+    except OSError as err:
+        if err.errno == EEXIST and os.path.isdir(dir_path):
+            pass
+        else:
+            raise
 
 
 class NeedleCaptureTest(PluginTester, TestCase):
@@ -50,6 +65,7 @@ class NeedleCaptureOverwriteTest(PluginTester, TestCase):
         self.assertFalse(os.path.exists(baseline_filename))
 
         # Create dummy baseline file
+        create_baseline_dir()
         baseline = open(baseline_filename, 'wb')
         baseline.write(dummy_baseline_content)
         baseline.close()
@@ -101,6 +117,7 @@ class SaveBaselineOverwriteTest(PluginTester, TestCase):
         self.assertFalse(os.path.exists(baseline_filename))
 
         # Create dummy baseline file
+        create_baseline_dir()
         baseline = open(baseline_filename, 'wb')
         baseline.write(dummy_baseline_content)
         baseline.close()
@@ -127,6 +144,7 @@ class NeedleCleanupOnSuccessTest(PluginTester, TestCase):
 
     def setUp(self):
         # Create the baseline
+        create_baseline_dir()
         baseline = open(baseline_filename, 'wb')
         baseline.write(open('tests/test_red_box.png', 'rb').read())
         baseline.close()

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
-envlist = py26,py27,py34,py35,py36
+envlist = py{27,34,35,36}-{chrome,firefox,phantomjs}
 
 [testenv]
 setenv =
-    NEEDLE_BROWSER = phantomjs
-commands = nosetests -v
+    chrome: NEEDLE_BROWSER=chrome
+    firefox: NEEDLE_BROWSER=firefox
+    phantomjs: NEEDLE_BROWSER=phantomjs
+commands = nosetests {posargs} -v


### PR DESCRIPTION
This resolves some errors I was getting with recent versions of Firefox and geckodriver, and also addresses #60 .

* Default to using operations from the W3C Web Driver spec to get dimensions and take element screenshots, falling back to the older Selenium commands if necessary (geckodriver has indicated that it [only intends to support the actual spec](https://github.com/mozilla/geckodriver/issues/471), not the legacy Selenium commands).
* Work around a [Selenium bug](https://github.com/SeleniumHQ/selenium/issues/767) introduced in April 2015 that sometimes leaves orphaned phantomjs processes behind.
* Updated the tox configuration to support testing Chrome, Firefox, and/or PhantomJS.
* Test both PhantomJS and Firefox in Travis (Chrome should be possible also, but I don't want to attempt that many changes to the Travis configuration at the same time).
* Fixed some tests that would fail if run in isolation, only passing when other tests created some directories for them.
* Stopped testing Python 2.6 in tox, since Travis wasn't testing it and even pip and setuptools no longer support it.