### PR TITLE
Test reliability fixes

### DIFF
--- a/needle/cases.py
+++ b/needle/cases.py
@@ -6,6 +6,7 @@ from warnings import warn
 from contextlib import contextmanager
 from errno import EEXIST
 import os
+import signal
 import sys
 
 if sys.version_info > (2, 7):
@@ -78,6 +79,10 @@ class NeedleTestCase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        if isinstance(cls.driver, NeedlePhantomJS):
+            # Workaround for https://github.com/SeleniumHQ/selenium/issues/767
+            cls.driver.service.send_remote_shutdown_command()
+            cls.driver.service._cookie_temp_file = None
         cls.driver.quit()
         super(NeedleTestCase, cls).tearDownClass()
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,7 @@
+import logging
 import sys
 import os
+from errno import EEXIST
 
 from needle.plugin import NeedleCapturePlugin, SaveBaselinePlugin, CleanUpOnSuccessPlugin
 from nose.plugins import PluginTester
@@ -13,30 +15,61 @@ else:
 baseline_filename = 'screenshots/baseline/red_box.png'
 screenshot_filename = 'screenshots/red_box.png'
 dummy_baseline_content = b'abcd'
+log = logging.getLogger(__name__)
+
+def create_baseline_dir():
+    """
+    Create the baseline images directory if it doesn't already exist.
+    """
+    dir_path = 'screenshots/baseline'
+    try:
+        os.makedirs(dir_path)
+    except OSError as err:
+        if err.errno == EEXIST and os.path.isdir(dir_path):
+            pass
+        else:
+            raise
 
 
-class NeedleCaptureTest(PluginTester, TestCase):
+class NeedlePluginTester(PluginTester):
+    """
+    Base class for tests of needle's nose plugins.
+    """
+    suitepath = 'tests/plugin_test_cases/red_box.py'
+
+    def setUp(self):
+        """
+        Run the wrapped test suite and log its output for use in debugging
+        failures.
+        """
+        super(NeedlePluginTester, self).setUp()
+        log.debug(self.output)
+
+    def tearDown(self):
+        """
+        Remove the baseline image created by the test.
+        """
+        os.remove(baseline_filename)
+
+
+class NeedleCaptureTest(NeedlePluginTester, TestCase):
     """
     Check that the baseline file gets saved when using the
     --with-needle-capture option.
     """
     activate = '--with-needle-capture'
     plugins = [NeedleCapturePlugin()]
-    suitepath = 'tests/plugin_test_cases/red_box.py'
 
     def setUp(self):
         self.assertFalse(os.path.exists(baseline_filename))
         super(NeedleCaptureTest, self).setUp()
-
-    def tearDown(self):
-        os.remove(baseline_filename)
 
     def test_baseline_is_saved(self):
         self.assertTrue(os.path.exists(baseline_filename))
         self.assertTrue(self.nose.success)
 
 
-class NeedleCaptureOverwriteTest(PluginTester, TestCase):
+class NeedleCaptureOverwriteTest(NeedlePluginTester, TestCase):
     """
     Check that an existing baseline file does NOT get overwritten, when using
     the --with-needle-capture option.
@@ -44,20 +77,17 @@ class NeedleCaptureOverwriteTest(PluginTester, TestCase):
 
     activate = '--with-needle-capture'
     plugins = [NeedleCapturePlugin()]
-    suitepath = 'tests/plugin_test_cases/red_box.py'
 
     def setUp(self):
         self.assertFalse(os.path.exists(baseline_filename))
 
         # Create dummy baseline file
+        create_baseline_dir()
         baseline = open(baseline_filename, 'wb')
         baseline.write(dummy_baseline_content)
         baseline.close()
 
         super(NeedleCaptureOverwriteTest, self).setUp()
-
-    def tearDown(self):
-        os.remove(baseline_filename)
 
     def test_existing_baseline_not_overwritten(self):
         baseline = open(baseline_filename, 'rb')
@@ -66,28 +96,24 @@ class NeedleCaptureOverwriteTest(PluginTester, TestCase):
 
 
 
-class SaveBaselineTest(PluginTester, TestCase):
+class SaveBaselineTest(NeedlePluginTester, TestCase):
     """
     Check that the baseline file gets saved when using the
     --with-save-baseline option.
     """
     activate = '--with-save-baseline'
     plugins = [SaveBaselinePlugin()]
-    suitepath = 'tests/plugin_test_cases/red_box.py'
 
     def setUp(self):
         self.assertFalse(os.path.exists(baseline_filename))
         super(SaveBaselineTest, self).setUp()
-
-    def tearDown(self):
-        os.remove(baseline_filename)
 
     def test_baseline_is_saved(self):
         self.assertTrue(os.path.exists(baseline_filename))
         self.assertTrue(self.nose.success)
 
 
-class SaveBaselineOverwriteTest(PluginTester, TestCase):
+class SaveBaselineOverwriteTest(NeedlePluginTester, TestCase):
     """
     Check that an existing baseline file DOES get overwritten, when using
     the --with-save-baseline option.
@@ -95,20 +121,17 @@ class SaveBaselineOverwriteTest(PluginTester, TestCase):
 
     activate = '--with-save-baseline'
     plugins = [SaveBaselinePlugin()]
-    suitepath = 'tests/plugin_test_cases/red_box.py'
 
     def setUp(self):
         self.assertFalse(os.path.exists(baseline_filename))
 
         # Create dummy baseline file
+        create_baseline_dir()
         baseline = open(baseline_filename, 'wb')
         baseline.write(dummy_baseline_content)
         baseline.close()
 
         super(SaveBaselineOverwriteTest, self).setUp()
-
-    def tearDown(self):
-        os.remove(baseline_filename)
 
     def test_existing_baseline_is_overwritten(self):
         baseline = open(baseline_filename, 'rb')
@@ -116,17 +139,17 @@ class SaveBaselineOverwriteTest(PluginTester, TestCase):
         self.assertTrue(self.nose.success)
 
 
-class NeedleCleanupOnSuccessTest(PluginTester, TestCase):
+class NeedleCleanupOnSuccessTest(NeedlePluginTester, TestCase):
     """
     Check that the screenshot gets removed when using the
     needle-cleanup-on-success option.
     """
     activate = '--with-needle-cleanup-on-success'
     plugins = [CleanUpOnSuccessPlugin()]
-    suitepath = 'tests/plugin_test_cases/red_box.py'
 
     def setUp(self):
         # Create the baseline
+        create_baseline_dir()
         baseline = open(baseline_filename, 'wb')
         baseline.write(open('tests/test_red_box.png', 'rb').read())
         baseline.close()
@@ -134,9 +157,6 @@ class NeedleCleanupOnSuccessTest(PluginTester, TestCase):
         # Make sure the screenshot doesn't exist yet
         self.assertFalse(os.path.exists(screenshot_filename))
         super(NeedleCleanupOnSuccessTest, self).setUp()
-
-    def tearDown(self):
-        os.remove(baseline_filename)
 
     def test_screenshot_is_cleanedup(self):
         # Make sure the screenshot has been cleaned up


### PR DESCRIPTION
Some fixes I needed just to get the existing needle tests to pass reliably when run locally (extracted from #63 ):

* Explicitly call `send_remote_shutdown_command()` for the PhantomJS service and clean up after it before calling `driver.quit()`; otherwise it sometimes gets called twice, throws an exception the second time, and leaves an orphaned process sitting around consuming CPU cycles.  This is a workaround for this [upstream selenium issue](https://github.com/SeleniumHQ/selenium/issues/3216), which apparently isn't fixed in 3.3.1 as claimed.
* Print the output of the wrapped test runs from PluginTester subclasses.  The PhantomJS shutdown failures mentioned above were sometimes triggering exceptions in the wrapped `tearDownClass`, so `self.nose.success` was False but there was no indication of why.  This output is only shown in the console when the test actually fails, so it doesn't clutter up successful test runs.  Some of the tests in my previous PR were still failing like this in Travis with no useful feedback, so hopefully this will help debug any remaining issues.
* Fixed the setup of the PluginTester subclasses so they pass when run in isolation (they had been relying on previous tests in the suite to create the baseline directory for them).

For reference, the exact traceback I was getting consistently for NeedleCleanupOnSuccessTest under Python 2.7:

```
.E
======================================================================
ERROR: test suite for <class 'red_box.RedBoxTestCase'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jeremybowman/Source/needle/.tox/py27/lib/python2.7/site-packages/nose/suite.py", line 228, in run
    self.tearDown()
  File "/Users/jeremybowman/Source/needle/.tox/py27/lib/python2.7/site-packages/nose/suite.py", line 351, in tearDown
    self.teardownContext(ancestor)
  File "/Users/jeremybowman/Source/needle/.tox/py27/lib/python2.7/site-packages/nose/suite.py", line 367, in teardownContext
    try_run(context, names)
  File "/Users/jeremybowman/Source/needle/.tox/py27/lib/python2.7/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/Users/jeremybowman/Source/needle/needle/cases.py", line 81, in tearDownClass
    cls.driver.quit()
  File "/Users/jeremybowman/Source/needle/.tox/py27/lib/python2.7/site-packages/selenium/webdriver/phantomjs/webdriver.py", line 76, in quit
    self.service.stop()
  File "/Users/jeremybowman/Source/needle/.tox/py27/lib/python2.7/site-packages/selenium/webdriver/common/service.py", line 149, in stop
    self.send_remote_shutdown_command()
  File "/Users/jeremybowman/Source/needle/.tox/py27/lib/python2.7/site-packages/selenium/webdriver/phantomjs/service.py", line 67, in send_remote_shutdown_command
    os.close(self._cookie_temp_file_handle)
OSError: [Errno 9] Bad file descriptor

----------------------------------------------------------------------
Ran 1 test in 1.380s
```