### PR TITLE
Support Firefox via geckodriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: required
+dist: trusty
 python:
   - "2.7"
   - "3.2"
@@ -7,14 +8,29 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+# Firefox 48+ only works with geckodriver, first supported properly in selenium 3.0.0.b3
+# See https://github.com/SeleniumHQ/selenium/issues/2739#issuecomment-249482533
 env:
-  - SELENIUM_VERSION='<3'
-  - SELENIUM_VERSION='<4'
+  - SELENIUM_VERSION='<3' NEEDLE_BROWSER=chrome
+  - SELENIUM_VERSION='<4' NEEDLE_BROWSER=chrome
+  - SELENIUM_VERSION='<4' NEEDLE_BROWSER=firefox
+  - SELENIUM_VERSION='<3' NEEDLE_BROWSER=phantomjs
+  - SELENIUM_VERSION='<4' NEEDLE_BROWSER=phantomjs
 before_install:
+  - if [[ "$NEEDLE_BROWSER" != "phantomjs" ]]; then export DISPLAY=:99.0; fi
+  - if [[ "$NEEDLE_BROWSER" != "phantomjs" ]]; then sh -e /etc/init.d/xvfb start; fi
+  - if [[ "$NEEDLE_BROWSER" == "firefox" ]]; then wget https://github.com/mozilla/geckodriver/releases/download/v0.15.0/geckodriver-v0.15.0-linux64.tar.gz; fi
+  - if [[ "$NEEDLE_BROWSER" == "firefox" ]]; then mkdir geckodriver; fi
+  - if [[ "$NEEDLE_BROWSER" == "firefox" ]]; then tar -xzf geckodriver-v0.15.0-linux64.tar.gz -C geckodriver; fi
+  - if [[ "$NEEDLE_BROWSER" == "firefox" ]]; then export PATH=$PATH:$PWD/geckodriver; fi
   - sudo apt-get update -qq
   - sudo apt-get install -y perceptualdiff imagemagick
+  - if [[ "$NEEDLE_BROWSER" == "chrome" ]]; then sudo apt-get install -y chromium-chromedriver; fi
+  - if [[ "$NEEDLE_BROWSER" == "chrome" ]]; then export PATH=$PATH:/usr/lib/chromium-browser/; fi
+addons:
+  firefox: '52.0'
 install:
   - pip install "selenium ${SELENIUM_VERSION}"
   - pip install -e .
 script:
-  - NEEDLE_BROWSER=phantomjs nosetests -v
+  - nosetests -v

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
-envlist = py26,py27,py34,py35,py36
+envlist = py{27,34,35,36}-{chrome,firefox,phantomjs}
 
 [testenv]
 setenv =
-    NEEDLE_BROWSER = phantomjs
-commands = nosetests -v
+    chrome: NEEDLE_BROWSER=chrome
+    firefox: NEEDLE_BROWSER=firefox
+    phantomjs: NEEDLE_BROWSER=phantomjs
+commands = nosetests {posargs} -v


### PR DESCRIPTION
Add support for using needle with recent versions of Firefox via geckodriver:

* Try `rect` from the W3C WebDriver spec before falling back to the Selenium `location` and `size` calls if necessary (geckodriver [doesn't support](https://github.com/mozilla/geckodriver/issues/471) the latter).
* Try directly getting a screenshot of the target element (supported for some drivers starting in selenium 2.46.1) before falling back to cropping a full-page screenshot if necessary.  The fallback doesn't work correctly in geckodriver, so we can't just consistently use the legacy approach for all drivers.
* Update the tox configuration to simplify testing with Firefox and Chrome.  Both pass all tests for me locally.
* Update the Travis configuration to also test Firefox/geckodriver with the latest selenium release.  The selenium 2.x releases have a bug that often prevents Firefox from launching correctly, so I don't recommend using or testing that combination.  The additional setup needed to run Firefox and geckodriver is skipped for PhantomJS test workers.

This seems like the minimum necessary step towards working, tested geckodriver support, but let me know if you want to split it up further into smaller PRs.