### PR TITLE
Give more time for XVFB and drivers to start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
 before_install:
   - if [[ "$NEEDLE_BROWSER" != "phantomjs" ]]; then export DISPLAY=:99.0; fi
   - if [[ "$NEEDLE_BROWSER" != "phantomjs" ]]; then sh -e /etc/init.d/xvfb start; fi
+  - if [[ "$NEEDLE_BROWSER" != "phantomjs" ]]; then sleep 3; fi # give xvfb some time to start
   - if [[ "$NEEDLE_BROWSER" == "firefox" ]]; then wget https://github.com/mozilla/geckodriver/releases/download/v0.15.0/geckodriver-v0.15.0-linux64.tar.gz; fi
   - if [[ "$NEEDLE_BROWSER" == "firefox" ]]; then mkdir geckodriver; fi
   - if [[ "$NEEDLE_BROWSER" == "firefox" ]]; then tar -xzf geckodriver-v0.15.0-linux64.tar.gz -C geckodriver; fi


### PR DESCRIPTION
The first Firefox test in a Travis job for a previous test run got a "Connection refused" WebDriverException when attempting to get the driver, perhaps because xvfb hadn't finished initializing yet.  Give it a [little more time](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI) in Travis jobs, and allow a few attempts to get the driver in case the first attempt hits a similar selenium exception.