### PR TITLE
Have git ignore more local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,12 @@
 .*.swp
 .*.swn
 .*.swm
+/.tox/
 /build/
 /dist/
 selenium-server-standalone-*.jar
 /docs/_build
 tests/screenshots/*.png
+geckodriver.log
 ghostdriver.log
 __pycache__


### PR DESCRIPTION
Don't tempt people into accidentally checking in geckodriver logs, tox testing virtualenvs, or JetBrains IDE configuration files.