### PR TITLE
Add tox env for building docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,6 @@ The documentation will then be available browsable from
 Running Needle's test suite
 ---------------------------
 
-    $ nosetests
+First install tox (usually via ``pip install tox``).  Then:
+
+    $ tox

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,7 @@ html_theme = 'nature'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/tox.ini
+++ b/tox.ini
@@ -7,3 +7,8 @@ setenv =
     firefox: NEEDLE_BROWSER=firefox
     phantomjs: NEEDLE_BROWSER=phantomjs
 commands = nosetests {posargs} -v
+
+[testenv:docs]
+deps = Sphinx
+commands =
+    sphinx-build -W -b {posargs:html} docs docs/_build


### PR DESCRIPTION
Add a tox environment for building the docs, and update the README to recommend tox for running tests.  This should wrap up all of the changes originally proposed in #20 .

This is about the end of the changes I was planning to make in the near future.  Any thoughts on when to make a new release?  I need to make some updates to [bok-choy](https://github.com/edx/bok-choy), and would rather not switch it over to installing needle from git.