### PR TITLE
Fix W3C driver detection for WebElements

### DIFF
--- a/needle/driver.py
+++ b/needle/driver.py
@@ -41,13 +41,8 @@ class NeedleWebElement(WebElement):
         Returns a dictionary containing, in pixels, the element's ``width`` and
         ``height``, and it's ``left`` and ``top`` position relative to the document.
         """
-        try:
-            # For selenium >= 2.50.1, W3C WebDriver spec drivers (like geckodriver)
-            location = size = self.rect
-        except (AttributeError, WebDriverException):
-            # For older selenium versions or older Selenium API drivers (like PhantomJS)
-            location = self.location
-            size = self.size
+        location = self.location
+        size = self.size
         return {
             "top": location['y'],
             "left": location['x'],
@@ -118,8 +113,8 @@ class NeedleWebDriverMixin(object):
     def _get_js_path(self):
         return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'js')
 
-    def create_web_element(self, *args, **kwargs):
-        return NeedleWebElement(self, *args, **kwargs)
+    def create_web_element(self, element_id, *args, **kwargs):
+        return NeedleWebElement(self, element_id, w3c=self.w3c, *args, **kwargs)
 
 
 class NeedleRemote(NeedleWebDriverMixin, Remote):


### PR DESCRIPTION
Fun fact: in the Selenium Python bindings, but not explained at all in the documentation for it, is support for auto-detecting whether a particular web driver implements the W3C spec or the Selenium API.  If the former, it then implements a number of shims automatically so existing code often doesn't need to be changed to understand the difference.  As it turns out, the implementation of passing that knowledge from the driver to each WebElement is in `create_web_driver()` - which needle overrides.

I fixed needle's implementation to include that piece of knowledge transfer, and now the try/except in `get_dimensions()` is no longer needed (once Selenium knows it's dealing with a W3C spec-based driver, it automatically calls the "rect" command instead of "location" or "size").  The screenshot changes we committed earlier are still needed, since Selenium doesn't have that kind of shim to get a screenshot of just a particular element for Selemium API drivers.

That `self.w3c` attribute has been present since selenium 2.47.0; I can add a condition check to make it work with even older versions if you'd like, but I'm not sure it's worth the added code complexity (that release came out almost 2 years ago).