### PR TITLE
Use FirefoxWebElement when appropriate

### DIFF
--- a/needle/cases.py
+++ b/needle/cases.py
@@ -24,7 +24,7 @@ from selenium.common.exceptions import WebDriverException
 
 from needle.engines.pil_engine import ImageDiff
 from needle.driver import (NeedleFirefox, NeedleChrome, NeedleIe, NeedleOpera,
-                           NeedleSafari, NeedlePhantomJS, NeedleWebElement)
+                           NeedleSafari, NeedlePhantomJS, NeedleWebElementMixin)
 
 DRIVER_ACQUISITION_TIMEOUT = 5  # seconds
 
@@ -113,7 +113,10 @@ class NeedleTestCase(TestCase):
             try:
                 browser = browser_class()
                 break
-            except WebDriverException:
+            except Exception as e:
+                if (not isinstance(e, WebDriverException)) and e.__class__.__name__ != 'WebDriverException':
+                    # nose likes to change selenium's WebDriverException to "nose.proxy.WebDriverException"
+                    raise
                 if time.time() - start_time >= DRIVER_ACQUISITION_TIMEOUT:
                     raise
                 time.sleep(1)
@@ -174,7 +177,7 @@ class NeedleTestCase(TestCase):
 
         :param element_or_selector:
             Either a CSS selector as a string or a
-            :py:class:`~needle.driver.NeedleWebElement` object that represents
+            :py:class:`~needle.driver.NeedleWebElementMixin` object that represents
             the element to capture.
         :param file:
             If a string, then assumed to be the filename for the screenshot,
@@ -186,7 +189,7 @@ class NeedleTestCase(TestCase):
 
         yield  # To allow using this method as a context manager
 
-        if not isinstance(element_or_selector, NeedleWebElement):
+        if not isinstance(element_or_selector, NeedleWebElementMixin):
             element = self.driver.find_element_by_css_selector(element_or_selector)
         else:
             element = element_or_selector

--- a/needle/driver.py
+++ b/needle/driver.py
@@ -28,8 +28,14 @@ from selenium.webdriver.safari.webdriver import WebDriver as Safari
 from selenium.webdriver.phantomjs.webdriver import WebDriver as PhantomJS
 from selenium.webdriver.remote.webdriver import WebDriver as Remote
 
+try:
+    # Added in selenium 3.0.0.b3
+    from selenium.webdriver.firefox.webelement import FirefoxWebElement
+except ImportError:
+    from selenium.webdriver.remote.webelement import WebElement as FirefoxWebElement
 
-class NeedleWebElement(WebElement):
+
+class NeedleWebElementMixin(object):
     """
     An element on a page that Selenium has opened.
 
@@ -114,7 +120,10 @@ class NeedleWebDriverMixin(object):
         return os.path.join(os.path.dirname(os.path.abspath(__file__)), 'js')
 
     def create_web_element(self, element_id, *args, **kwargs):
-        return NeedleWebElement(self, element_id, w3c=self.w3c, *args, **kwargs)
+        if isinstance(self, NeedleFirefox):
+            return NeedleFirefoxWebElement(self, element_id, w3c=self.w3c, *args, **kwargs)
+        else:
+            return NeedleWebElement(self, element_id, w3c=self.w3c, *args, **kwargs)
 
 
 class NeedleRemote(NeedleWebDriverMixin, Remote):
@@ -156,5 +165,17 @@ class NeedleOpera(NeedleWebDriverMixin, Opera):
 class NeedleSafari(NeedleWebDriverMixin, Safari):
     """
     The same as Selenium's Safari WebDriver, but with NeedleWebDriverMixin's
+    functionality.
+    """
+
+class NeedleWebElement(NeedleWebElementMixin, WebElement):
+    """
+    The same as Selenium's WebElement, but with NeedleWebElementMixin's
+    functionality.
+    """
+
+class NeedleFirefoxWebElement(NeedleWebElementMixin, FirefoxWebElement):
+    """
+    The same as Selenium's FirefoxWebElement, but with NeedleWebElementMixin's
     functionality.
     """


### PR DESCRIPTION
In selenium 3.0.0.b3, a FirefoxWebElement class was added.  The driver keeps track of which class is the appropriate one to use for elements in its `_web_element_cls` attribute, and when serializing arguments to `execute_script()`, determines if an argument is an element (which has a custom serialized representation) by whether or not it inherits that class.  Because NeedleWebElement doesn't inherit from FirefoxWebElement, this was causing selenium to instead try to encode the object as JSON (which threw an exception).  None of needle's test cases ran afoul of this, but calls to `get_attribute()` in bok-choy's tests did.

I turned the custom web element functionality into a mixin, and defined one web element class inheriting it for Firefox and another for all other browsers (Firefox is the only browser supported by needle which currently has a custom web element class).

I think this is the last thing I have to fix for the bok-choy tests to pass, hopefully I don't find more when running some of the tests in other repos that use bok-choy...