### PR TITLE
Fix space problem in paths 

### DIFF
--- a/needle/engines/imagemagick_engine.py
+++ b/needle/engines/imagemagick_engine.py
@@ -21,7 +21,7 @@ class Engine(EngineBase):
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
         compare_stdout, compare_stderr = process.communicate()
-        print(compare_stderr)
+
         difference = float(compare_stderr.split()[1][1:-1])
         if difference <= threshold:
             os.remove(diff_file)

--- a/needle/engines/imagemagick_engine.py
+++ b/needle/engines/imagemagick_engine.py
@@ -5,23 +5,23 @@ from needle.engines.base import EngineBase
 
 
 class Engine(EngineBase):
+    
     compare_path = "compare"
-    compare_command = ("{compare} -metric RMSE -subimage-search -dissimilarity-threshold 1.0 {baseline} "
-                       "{new} {diff}")
 
     def assertSameFiles(self, output_file, baseline_file, threshold=0):
         diff_file = output_file.replace('.png', '.diff.png')
 
-        compare_cmd = self.compare_command.format(
-            compare=self.compare_path,
-            baseline=baseline_file,
-            new=output_file,
-            diff=diff_file)
-        process = subprocess.Popen(compare_cmd, shell=True,
+        compare_command = [self.compare_path,
+                           "-metric","RMSE",
+                           "-subimage-search",
+                           "-dissimilarity-threshold","1.0",
+                           baseline_file, output_file, diff_file]
+
+        process = subprocess.Popen(compare_command, shell=True,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
         compare_stdout, compare_stderr = process.communicate()
-
+        print(compare_stderr)
         difference = float(compare_stderr.split()[1][1:-1])
         if difference <= threshold:
             os.remove(diff_file)

--- a/needle/engines/wand_engine.py
+++ b/needle/engines/wand_engine.py
@@ -21,7 +21,7 @@ class Engine(EngineBase):
         if difference <= threshold:
             return
         else:
-            comparison.save(diff_file)
+            comparison.save(filename=diff_file)
 
         raise AssertionError("The new screenshot '{new}' did not match "
                              "the baseline '{baseline}' (See {diff}):\n"

--- a/needle/engines/wand_engine.py
+++ b/needle/engines/wand_engine.py
@@ -1,4 +1,5 @@
 from wand.image import Image
+import os
 from needle.engines.base import EngineBase
 
 

--- a/needle/engines/wand_engine.py
+++ b/needle/engines/wand_engine.py
@@ -1,0 +1,29 @@
+from wand.image import Image
+from needle.engines.base import EngineBase
+
+
+class Engine(EngineBase):
+    
+
+    def assertSameFiles(self, output_file, baseline_file, threshold=0):
+
+        diff_file = output_file.replace('.png', '.diff.png')
+
+        img_base = Image(filename=os.path.abspath(baseline_file))
+        img_out =  Image(filename=os.path.abspath(output_file))
+
+        img_base.normalize()
+        img_out.normalize()
+
+        comparison, difference = img_base.compare(img_out, metric='root_mean_square')
+            
+        if difference <= threshold:
+            return
+        else:
+            comparison.save(diff_file)
+
+        raise AssertionError("The new screenshot '{new}' did not match "
+                             "the baseline '{baseline}' (See {diff}):\n"
+                             .format(new=output_file,
+                                     baseline=baseline_file,
+                                     diff=diff_file))

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_requires = [
     'nose>=1.0.0',
     'selenium>=2,<4',
     'pillow',
+    'wand>=0.5.0'
 ]
 
 if sys.version_info < (2, 7, 0):


### PR DESCRIPTION
Fix defect when ImageMagic compare utility or screenshot paths have space and tests were fall with error.
Sandbox:
Windows 7 x64
Python 3.6.5 x32